### PR TITLE
[keycloak-gatekeeper] added --skip-upstream-tls-verify option

### DIFF
--- a/charts/keycloak-gatekeeper/Chart.yaml
+++ b/charts/keycloak-gatekeeper/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - authorization
   - keycloak
   - proxy
-version: 1.0.2
+version: 1.1.0
 engine: gotpl
 maintainers:
   - name: gabibbo97

--- a/charts/keycloak-gatekeeper/README.md
+++ b/charts/keycloak-gatekeeper/README.md
@@ -28,6 +28,7 @@ This can be used with Kubernetes-dashboard, Grafana, Jenkins, ...
 | -------------- | ---------------------------------------------------------- | :-----: |
 | `discoveryURL` | URL for OpenID autoconfiguration                           | ``      |
 | `upstreamURL`  | URL of the service to proxy                                | ``      |
+| `skipUpstreamTlsVerify`  | URL of the service to proxy                      | ``      |
 | `ClientID`     | Client ID for OpenID server                                | ``      |
 | `ClientSecret` | Client secret for OpenID server                            | ``      |
 | `scopes`       | Additional required scopes for authentication              | `[]`    |

--- a/charts/keycloak-gatekeeper/templates/deployment.yaml
+++ b/charts/keycloak-gatekeeper/templates/deployment.yaml
@@ -40,6 +40,7 @@ spec:
             - --client-id=$(CLIENT_ID)
             - --client-secret=$(CLIENT_SECRET)
             - --upstream-url={{ .Values.upstreamURL }}
+            - --skip-upstream-tls-verify={{ .Values.skipUpstreamTlsVerify }}
             - --enable-default-deny
             - --enable-logging
             - --enable-refresh-tokens

--- a/charts/keycloak-gatekeeper/values.yaml
+++ b/charts/keycloak-gatekeeper/values.yaml
@@ -55,6 +55,9 @@ discoveryURL: ""
 # upstreamURL: http://my-service.my-namespace.svc.cluster.local:8088
 upstreamURL: ""
 
+# skip upstream url tls verification
+skip-upstream-tls-verify: false
+
 # OpenID ClientID and secret
 ClientID: ""
 ClientSecret: ""


### PR DESCRIPTION
added the "--skip-upstream-tls-verify option" to be able to work with letsencrypt staging certificates.