### PR TITLE
Add configuration options, upgrade to 4.8.0.Final

### DIFF
--- a/charts/keycloak-gatekeeper/Chart.yaml
+++ b/charts/keycloak-gatekeeper/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "4.6.0.Final"
+appVersion: "4.8.0.Final"
 description: Keycloak gatekeeper
 name: keycloak-gatekeeper
 home: https://github.com/keycloak/keycloak-gatekeeper
@@ -9,7 +9,7 @@ keywords:
   - authorization
   - keycloak
   - proxy
-version: 1.1.1
+version: 1.2.0
 engine: gotpl
 maintainers:
   - name: gabibbo97

--- a/charts/keycloak-gatekeeper/README.md
+++ b/charts/keycloak-gatekeeper/README.md
@@ -24,18 +24,25 @@ This can be used with Kubernetes-dashboard, Grafana, Jenkins, ...
 
 ## Configuration options
 
-| Parameter      | Description                                                | Default |
-| -------------- | ---------------------------------------------------------- | :-----: |
-| `discoveryURL` | URL for OpenID autoconfiguration                           | ``      |
-| `upstreamURL`  | URL of the service to proxy                                | ``      |
-| `skipUpstreamTlsVerify`  | URL of the service to proxy                      | ``      |
-| `ClientID`     | Client ID for OpenID server                                | ``      |
-| `ClientSecret` | Client secret for OpenID server                            | ``      |
-| `scopes`       | Additional required scopes for authentication              | `[]`    |
-| `addClaims`    | Set these claims as headers in the request for the backend | `[]`    |
-| `matchClaims`  | Key-Value pairs that the JWT should contain                | `{}`    |
-| `rules`        | Specify fine grained rules for authentication              | `[]`    |
-| `debug`        | Use verbose logging                                        | `false` |
+| Parameter        | Description                                                | Default |
+| ---------------- | ---------------------------------------------------------- | :-----: |
+| `discoveryURL`   | URL for OpenID autoconfiguration                           | ``      |
+| `upstreamURL`    | URL of the service to proxy                                | ``      |
+| `skipUpstreamTlsVerify` | URL of the service to proxy                         | ``      |
+| `ClientID`       | Client ID for OpenID server                                | ``      |
+| `ClientSecret`   | Client secret for OpenID server                            | ``      |
+| `scopes`         | Additional required scopes for authentication              | `[]`    |
+| `addClaims`      | Set these claims as headers in the request for the backend | `[]`    |
+| `matchClaims`    | Key-Value pairs that the JWT should contain                | `{}`    |
+| `rules`          | Specify fine grained rules for authentication              | `[]`    |
+| `defaultDeny`    | Enable a default denial on all requests                    | `true`  |
+| `logging`        | Enable http logging of the requests                        | `true`  |
+| `refreshTokens`  | Enables the handling of the refresh tokens                 | `true`  |
+| `sessionCookies` | Set access and refresh tokens to be session only           | `true`  |
+| `droolsPolicyEnabled` | Enable support for Drools Policies (tech preview)     | `true`  |
+| `debug`          | Use verbose logging                                        | `false` |
+| `extraArgs`      | Additional command line arguments (as `option=value`)      | `[]`    |
+
 
 ## Setting up Keycloak
 
@@ -55,19 +62,19 @@ Each element of `resource` is a `|` (pipe separator) delimited list of key, valu
 
 Here is a non exhaustive list of key-value pairs
 
-| Example          | Description                                                        |
-| :--------------: | ------------------------------------------------------------------ |
-| uri=/private/*   | require access to subpaths of /private                             |
-| roles=admin,user | require the user to have both roles to access                      |
-| require-any-role | combined with roles above, switches the conditional from AND to OR |
-| white-listed     | allow anyone to have access                                        |
-| methods=GET,POST | apply authentication to these methods                              |
+| Example               | Description                                                        |
+| :-------------------: | ------------------------------------------------------------------ |
+| uri=/private/*        | require access to subpaths of /private                             |
+| roles=admin,user      | require the user to have both roles to access                      |
+| require-any-role=true | combined with roles above, switches the conditional from AND to OR |
+| white-listed=true     | allow anyone to have access                                        |
+| methods=GET,POST      | apply authentication to these methods                              |
 
 ## Example
 
 ```yaml
 resources:
-- "uri=/admin*|roles=admin,root|require-any-role"
+- "uri=/admin*|roles=admin,root|require-any-role=true"
 - "uri=/public*|white-listed=true"
 - "uri=/authenticated/users|roles=user"
 ```

--- a/charts/keycloak-gatekeeper/templates/deployment.yaml
+++ b/charts/keycloak-gatekeeper/templates/deployment.yaml
@@ -41,10 +41,10 @@ spec:
             - --client-secret=$(CLIENT_SECRET)
             - --upstream-url={{ .Values.upstreamURL }}
             - --skip-upstream-tls-verify={{ .Values.skipUpstreamTlsVerify }}
-            - --enable-default-deny
-            - --enable-logging
-            - --enable-refresh-tokens
-            - --enable-session-cookies
+            - --enable-default-deny={{ .Values.defaultDeny }}
+            - --enable-logging={{ .Values.logging }}
+            - --enable-refresh-tokens={{ .Values.refreshTokens }}
+            - --enable-session-cookies={{ .Values.sessionCookies }}
             {{- if not .Values.ingress.tls }}
             - --secure-cookie=false
             {{- end }}
@@ -75,6 +75,12 @@ spec:
             {{- end }}
             {{- if .Values.prometheusMetrics }}
             - --enable-metrics
+            {{- end }}
+            {{- if .Values.droolsPolicyEnabled }}
+            - -Dkeycloak.profile.feature.authz_drools_policy=enabled
+            {{- end }}
+            {{- range $i, $arg := .Values.extraArgs }}
+            - --{{ $arg }}
             {{- end }}
           envFrom:
             - secretRef:

--- a/charts/keycloak-gatekeeper/values.yaml
+++ b/charts/keycloak-gatekeeper/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: keycloak/keycloak-gatekeeper
-  tag: 4.6.0.Final
+  tag: 4.8.0.Final
   pullPolicy: IfNotPresent
 
 nameOverride: ""
@@ -58,6 +58,22 @@ upstreamURL: ""
 # skip upstream url tls verification
 skipUpstreamTlsVerify: false
 
+# enable a default denial on all requests, you have to explicitly say what is permitted (recommended)
+defaultDeny: true
+
+# enable http logging of the requests
+logging: true
+
+# enables the handling of the refresh tokens
+refreshTokens: true
+
+# access and refresh tokens are session only i.e. removed browser close
+sessionCookies: true
+
+# Drools policy support was enabled by default in 4.0 to 4.7,
+# but in 4.8 was disabled and marked technology preview
+droolsPolicyEnabled: true
+
 # OpenID ClientID and secret
 ClientID: ""
 ClientSecret: ""
@@ -83,11 +99,11 @@ matchClaims: {}
 # These rules specify different authentication strategies for different URLs
 # they follow this pattern: "key1=value1|key2=value2"
 # Here is a non exhaustive list of key-value pairs
-#   uri=/private/*    require access to subpaths of /private
-#   roles=admin,user  require the user to have both roles to access
-#   require-any-role  combined with roles above, switches the conditional from AND to OR
-#   white-listed      allow anyone to have access
-#   methods=GET,POST  apply authentication to these methods
+#   uri=/private/*         require access to subpaths of /private
+#   roles=admin,user       require the user to have both roles to access
+#   require-any-role=true  combined with roles above, switches the conditional from AND to OR
+#   white-listed=true      allow anyone to have access
+#   methods=GET,POST       apply authentication to these methods
 rules: []
 
 # Print verbose logs
@@ -106,3 +122,11 @@ serviceAccount:
 
 # Expose Prometheus metrics
 prometheusMetrics: true
+
+# add any additional command line arguments you want, without dashes
+# extraArgs:
+# - enable-https-redirection
+# - enable-authorization-header=false
+# - upstream-timeout=30s
+#
+extraArgs: []


### PR DESCRIPTION
This PR adds more flexibility to the chart by making some previously hard-coded choices now configurable and by adding the ability to add additional `keycloak-gatekeeper` command line arguments arbitrarily. It also upgrades the target app from version 4.6.0.Final to 4.8.0.Final (the latest 4.x version).

Previously, the following options were hardcoded:
- --enable-default-deny
- --enable-logging
- --enable-refresh-tokens
- --enable-session-cookies

With this PR, they continue to default to enabled, but can be disabled with corresponding settings in `values.yaml`. e.g. `defautlDeny: false`.

A new setting, `extraArgs`, takes a list of extra `keycloak-gatekeeper` command line arguments to add. There are over 90 command line options that could be set and it would be tedious to add every one of them as a setting, and this is adequate to let people easily add whatever settings they want. 

This PR also makes some minor corrections to the README. 