### PR TITLE
Add podAnnotations option, move checksum

### DIFF
--- a/charts/keycloak-gatekeeper/Chart.yaml
+++ b/charts/keycloak-gatekeeper/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - authorization
   - keycloak
   - proxy
-version: 1.2.0
+version: 1.2.1
 engine: gotpl
 maintainers:
   - name: gabibbo97

--- a/charts/keycloak-gatekeeper/README.md
+++ b/charts/keycloak-gatekeeper/README.md
@@ -42,7 +42,9 @@ This can be used with Kubernetes-dashboard, Grafana, Jenkins, ...
 | `droolsPolicyEnabled` | Enable support for Drools Policies (tech preview)     | `true`  |
 | `debug`          | Use verbose logging                                        | `false` |
 | `extraArgs`      | Additional command line arguments (as `option=value`)      | `[]`    |
+| `podAnnotations` | Additional annotations to add to the pod template          | ``      |
 
+See also the configuration variables used in [ingress.yaml](templates/ingress.yaml)
 
 ## Setting up Keycloak
 

--- a/charts/keycloak-gatekeeper/templates/deployment.yaml
+++ b/charts/keycloak-gatekeeper/templates/deployment.yaml
@@ -20,14 +20,17 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "keycloak-gatekeeper.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/configuration-checksum: {{ toJson .Values | sha256sum | trunc 48 | quote }}
         app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-      {{- if .Values.prometheusMetrics }}
       annotations:
+        checksum/config: {{ toJson .Values | sha256sum | trunc 48 | quote }}
+      {{- if .Values.prometheusMetrics }}
         prometheus.io/scrape: "true"
         prometheus.io/path: "/oauth/metrics"
         prometheus.io/port: "3000"
       {{- end }}
+{{- with .Values.podAnnotations }}
+{{ toYaml . | indent 8 }}
+{{- end }}
     spec:
       serviceAccountName: {{ include "keycloak-gatekeeper.serviceAccountName" . }}
       containers:


### PR DESCRIPTION
Minor but important changes:
1. Add `podAnnotations` configuration variable to allow for adding Kubernetes annotations to the pod
2. Move the configuration checksum from the nonstandard `app.kubernetes.io/configuration-checksum` label to the de facto standard `checksum/config` annotation
3. Bump the chart version from 1.2.0 to 1.2.1