### PR TITLE
add option to skip secret creation

### DIFF
--- a/charts/keycloak-gatekeeper/templates/secrets.yaml
+++ b/charts/keycloak-gatekeeper/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.secret.create }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,4 +11,5 @@ data:
   ENCRYPTION_KEY: {{ .Values.encryptionKey | b64enc | quote }}
 {{- else }}
   ENCRYPTION_KEY: {{ randAlphaNum 32 | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/charts/keycloak-gatekeeper/values.yaml
+++ b/charts/keycloak-gatekeeper/values.yaml
@@ -77,6 +77,10 @@ sessionCookies: true
 # but in 4.8 was disabled and marked technology preview
 droolsPolicyEnabled: false
 
+secret:
+  # Specifies whether the secret resource should be created
+  create: true
+
 # OpenID ClientID and secret
 ClientID: ""
 ClientSecret: ""


### PR DESCRIPTION
In our setup we manage application state from git, with secrets provided from an external vault by a k8s operator. Having an empty value as default chart value for CientID and ClientSecret, and a random encryption always makes the deployment out of sync (git state differs from live state). Not creating the secret resource from the chart allows the vault operator to be in charge of the secret, and k8s will block the startup of gatekeeper till the secret has been supplied.