### PR TITLE
Update keycloak-gatekeeper to 9.0.0, default to current apiVersion for Ingress

### DIFF
--- a/charts/keycloak-gatekeeper/Chart.yaml
+++ b/charts/keycloak-gatekeeper/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: keycloak-gatekeeper
-version: 2.1.0
+version: 2.2.0
 description: Keycloak gatekeeper
 type: application
 home: https://www.keycloak.org
@@ -16,4 +16,4 @@ maintainers:
   - name: gabibbo97
     email: gabibbo97@gmail.com
 icon: https://raw.githubusercontent.com/keycloak/keycloak-misc/master/logo/keycloak_logo_600px.svg
-appVersion: "8.0.1"
+appVersion: "9.0.0"

--- a/charts/keycloak-gatekeeper/templates/ingress.yaml
+++ b/charts/keycloak-gatekeeper/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "keycloak-gatekeeper.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress" }}
+{{- if or (.Capabilities.APIVersions.Has "networking.k8s.io/v1beta1/Ingress") (not (.Capabilities.APIVersions.Has "extensions/v1beta1/Ingress")) }}
 apiVersion: networking.k8s.io/v1beta1
 {{- else }}
 apiVersion: extensions/v1beta1


### PR DESCRIPTION
This PR makes 3 changes to the keycloak-gatekeeper chart:
1. Update the `appVersion` to the current 9.0.0
2. Change the default `apiVersion` for the `Ingress`
3. Bump the Chart version

Reasons for (1) and (3) are obvious.

Reason for (2): 
The current API version for Ingress is `networking.k8s.io/v1beta1`, replacing the older `extensions/v1beta1`. The chart helpfully checks to see that the cluster supports `networking.k8s.io/v1beta1` before installing such an Ingress, falling back to the `extensions/v1beta1` Ingress if it does not.

However, when running `helm diff`,  `Capabilities.APIVersions` is empty. This means that if you install the current chart on a cluster that has `networking.k8s.io/v1beta1/Ingress`, `helm diff` will show the installed `networking.k8s.io/v1beta1` Ingress being deleted and replaced with a new `extensions/v1beta1` Ingress. This is noise, and can be scary, making it look like the chart is going to revert to the older API version.

This PR makes the change that if `Capabilities.APIVersions` reports that the cluster does not support either `networking.k8s.io/v1beta1` OR `extensions/v1beta1` Ingress, then the newer `networking.k8s.io/v1beta1` is installed. In other words, the chart now defaults to the new API version when neither version appear to be supported, which is the case when running `helm diff`. 