### PR TITLE
[keycloak-gatekeeper] Remove double quotes from scopes arg

### DIFF
--- a/charts/keycloak-gatekeeper/templates/deployment.yaml
+++ b/charts/keycloak-gatekeeper/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
             {{- end }}
             {{- if .Values.scopes }}
             {{- range $i, $scope := .Values.scopes }}
-            - --scopes="{{ $scope }}"
+            - --scopes={{ $scope }}
             {{- end }}
             {{- end }}
             {{- if .Values.prometheusMetrics }}


### PR DESCRIPTION
Similar to https://github.com/gabibbo97/charts/pull/8

Double quotes are not needed here and make the argument value invalid.
