### PR TITLE
[keycloak-gatekeeper] Make the chart's apiVersion compatible with Helm v2

### DIFF
--- a/charts/keycloak-gatekeeper/Chart.yaml
+++ b/charts/keycloak-gatekeeper/Chart.yaml
@@ -1,8 +1,7 @@
-apiVersion: v2
+apiVersion: v1
 name: keycloak-gatekeeper
 version: 2.2.0
 description: Keycloak gatekeeper
-type: application
 home: https://www.keycloak.org
 sources:
   - https://github.com/keycloak/keycloak-containers

--- a/charts/keycloak-gatekeeper/Chart.yaml
+++ b/charts/keycloak-gatekeeper/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak-gatekeeper
-version: 2.2.0
+version: 3.0.0
 description: Keycloak gatekeeper
 home: https://www.keycloak.org
 sources:


### PR DESCRIPTION
Hi @gabibbo97 ,

Thank you for your `keycloak-gatekeeper` chart!  Can you please keep it compatible with Helm 2 for some time? That will help users like me to use the latest version of the chart and continue working on the Helm v3 migration.

This PR shows that the only incompatible thing there is the `type` field and `apiVersion`. All templates are working fine with both Helm 2 and 3

Thank you!