### PR TITLE
[keycloak-gatekeeper] Allow configuring extra container env

### DIFF
--- a/charts/keycloak-gatekeeper/Chart.yaml
+++ b/charts/keycloak-gatekeeper/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak-gatekeeper
-version: 3.1.0
+version: 3.2.0
 description: Keycloak gatekeeper
 home: https://www.keycloak.org
 sources:

--- a/charts/keycloak-gatekeeper/README.md
+++ b/charts/keycloak-gatekeeper/README.md
@@ -57,6 +57,7 @@ This can be used with Kubernetes-dashboard, Grafana, Jenkins, ...
 | `droolsPolicyEnabled`         | Enable support for Drools Policies (tech preview)            |                `false`                 |
 | `debug`                       | Use verbose logging                                          |                `false`                 |
 | `extraArgs`                   | Additional command line arguments (as `option=value`)        |                  `[]`                  |
+| `extraEnvs`                   | Additional `env` configuration for Container                 |                   ``                   |
 | `podAnnotations`              | Additional annotations to add to the pod template            |                   ``                   |
 
 See also the configuration variables used in [ingress.yaml](templates/ingress.yaml)

--- a/charts/keycloak-gatekeeper/templates/deployment.yaml
+++ b/charts/keycloak-gatekeeper/templates/deployment.yaml
@@ -93,6 +93,10 @@ spec:
                 name: {{ include "keycloak-gatekeeper.fullname" . }}-forwarding
                 optional: false
             {{- end }}
+          {{- with .Values.extraEnvs }}
+          env:
+{{ toYaml . | indent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 3000

--- a/charts/keycloak-gatekeeper/values.yaml
+++ b/charts/keycloak-gatekeeper/values.yaml
@@ -152,3 +152,15 @@ prometheusMetrics: true
 # - upstream-timeout=30s
 #
 extraArgs: []
+
+# add any additional container env entries you want here
+#  extraEnvs:
+#    - name: MY_NODE_NAME
+#      valueFrom:
+#        fieldRef:
+#          fieldPath: spec.nodeName
+#    - name: MY_POD_IP
+#      valueFrom:
+#        fieldRef:
+#          fieldPath: status.podIP
+extraEnvs: {}


### PR DESCRIPTION
Allow adding extra configuration to the deployment's `env` section. For example
```yaml
extraEnvs:
  - name: MY_NODE_NAME
    valueFrom:
      fieldRef:
        fieldPath: spec.nodeName
```

For me, this is useful in conjunction with `extraArgs` to set upstream headers
```yaml
extraArgs:
    - 'headers=X-Proxy-Node=$(MY_NODE_NAME)'
```