### PR TITLE
Make deployment kube-score-friendly

### DIFF
--- a/charts/keycloak-gatekeeper/Chart.yaml
+++ b/charts/keycloak-gatekeeper/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak-gatekeeper
-version: 3.2.0
+version: 3.2.1
 description: Keycloak gatekeeper
 home: https://www.keycloak.org
 sources:

--- a/charts/keycloak-gatekeeper/templates/deployment.yaml
+++ b/charts/keycloak-gatekeeper/templates/deployment.yaml
@@ -113,8 +113,9 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 1000
+            runAsUser: 10001
+            runAsGroup: 10001
+            privileged: false
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}


### PR DESCRIPTION
A kube-score of the deployment produces the following:

```
apps/v1/Deployment RELEASE-NAME-keycloak-gatekeeper                           💥
    [OK] Pod Probes
        · Pod has the same readiness and liveness probe
            It's recommended to have different probes for the two different
            purposes.
    [CRITICAL] Container Security Context
        · keycloak-gatekeeper -> The container is privileged
            Set securityContext.privileged to false
        · keycloak-gatekeeper -> The container is running with a low user ID
            A userid above 10 000 is recommended to avoid conflicts with the
            host. Set securityContext.runAsUser to a value > 10000
        · keycloak-gatekeeper -> The container running with a low group ID
            A groupid above 10 000 is recommended to avoid conflicts with the
            host. Set securityContext.runAsGroup to a value > 10000
v1/Service RELEASE-NAME-keycloak-gatekeeper                                   ✅
```

This PR simply bumps the `runAsUser` and `runAsGroup` values to > 10,000, and adds `privileged: false`, to satisfy kube-score (for those of us who have to pass kube-score in CI to get a deployment passed!)