### PR TITLE
Permit user to specify an image tag

### DIFF
--- a/charts/keycloak-gatekeeper/Chart.yaml
+++ b/charts/keycloak-gatekeeper/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: keycloak-gatekeeper
-version: 3.2.0
+version: 3.2.2
 description: Keycloak gatekeeper
 home: https://www.keycloak.org
 sources:

--- a/charts/keycloak-gatekeeper/templates/deployment.yaml
+++ b/charts/keycloak-gatekeeper/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: {{ include "keycloak-gatekeeper.serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.repository | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --listen=0.0.0.0:3000

--- a/charts/keycloak-gatekeeper/templates/deployment.yaml
+++ b/charts/keycloak-gatekeeper/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: {{ include "keycloak-gatekeeper.serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.repository | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --listen=0.0.0.0:3000


### PR DESCRIPTION
This change avoids "hard-coding" the template to use the current chart's appVersion, but rather allows the user to override the tag value, and "falls back" to the AppVersion if this is undefined. This should be a non-breaking change for the current chart.