### PR TITLE
RFC: Attempt to convert Guacamole to ingress 1.19

### DIFF
--- a/charts/guacamole/Chart.yaml
+++ b/charts/guacamole/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.0
+version: 0.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/guacamole/templates/frontend/ingress.yaml
+++ b/charts/guacamole/templates/frontend/ingress.yaml
@@ -1,6 +1,10 @@
 {{- if .Values.frontend.ingress.enabled }}
 ---
+{{- if semverCompare ">=1.19.0" $.Capabilities.KubeVersion.Version }}
+apiVersion: networking.k8s.io/v1
+{{- else }}
 apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ include "guacamole.fullname" . }}-frontend
@@ -8,6 +12,13 @@ metadata:
   annotations: {{- .Values.frontend.ingress.annotations | toYaml | nindent 4 }}
   labels: {{- include "guacamole.labels.frontend" . | nindent 4 }}
 spec:
+  {{- if .Values.frontend.ingress.class }}
+  {{- if semverCompare ">=1.19.0" $.Capabilities.KubeVersion.Version }}
+  ingressClassName: {{ .Values.frontend.ingress.class }}
+  {{- else }}
+  {{- fail "Please set the kubernetes.io/ingress.class annotation instead" }}
+  {{- end }}
+  {{- end }}
   {{- if .Values.frontend.ingress.hosts }}
   rules:
     {{- range $i, $host := .Values.frontend.ingress.hosts }}
@@ -16,9 +27,18 @@ spec:
         paths:
           {{- range $j, $path := $host.paths }}
           - path: {{ $path }}
+          {{- if semverCompare ">=1.19.0" $.Capabilities.KubeVersion.Version }}
+            pathType: Exact
+            backend:
+              service:
+                name: {{ include "guacamole.fullname" $ }}-frontend
+                port:
+                  name: http
+          {{- else }}
             backend:
               serviceName: {{ include "guacamole.fullname" $ }}-frontend
               servicePort: http
+          {{- end }}
           {{- end }}
     {{- end }}
   {{- end }}

--- a/charts/guacamole/values.yaml
+++ b/charts/guacamole/values.yaml
@@ -47,6 +47,7 @@ frontend:
     minAvailable: 1
   ingress:
     enabled: false
+    class: 'nginx'
     annotations:
       nginx.ingress.kubernetes.io/app-root: /guacamole
       nginx.ingress.kubernetes.io/proxy-buffering: "off"
@@ -89,10 +90,10 @@ hooks:
   #
   initializeDatabase:
     enabled: true
-    postgresImage: postgres:12.3
+    postgresImage: postgres:13
   #
   # Updates the provided database on chart update
   #
   upgradeDatabase:
     enabled: true
-    postgresImage: postgres:12.3
+    postgresImage: postgres:13


### PR DESCRIPTION
Does this work on your clusters?

Check that the resulting ingress is of the correct non deprecated kind (`networking.k8s/v1/Ingress`)

I will automerge this after some time

Ref: #34 