### PR TITLE
Change pathType to Prefix

### DIFF
--- a/charts/guacamole/templates/frontend/ingress.yaml
+++ b/charts/guacamole/templates/frontend/ingress.yaml
@@ -28,7 +28,7 @@ spec:
           {{- range $j, $path := $host.paths }}
           - path: {{ $path }}
           {{- if semverCompare ">=1.19.0" $.Capabilities.KubeVersion.Version }}
-            pathType: Exact
+            pathType: Prefix
             backend:
               service:
                 name: {{ include "guacamole.fullname" $ }}-frontend


### PR DESCRIPTION
If the pathType is set to Exact, it wouldn't match any subpath. For example, if paths is defined as ['/guacamole'], https://.../guacamole would work but the automatic redirection to https://.../guacamole/#/ throws a 404 error.