### PR TITLE
Guacamole 1.30

### DIFF
--- a/charts/guacamole/Chart.yaml
+++ b/charts/guacamole/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.1
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.2.0
+appVersion: 1.3.0


### PR DESCRIPTION
Guacamole 1.3.0 was released a couple of weeks ago. I didn't notice any change that could impact this chart in the release notes (https://guacamole.apache.org/releases/1.3.0/).
I also forgot to bump up the chart version in my previous pull request to fix the pathType.

Thanks :)