### PR TITLE
feat(existingSecret): allow a secret to be already existent

### DIFF
--- a/charts/gangway/Chart.yaml
+++ b/charts/gangway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gangway
-version: 1.0.3
+version: 1.1.0
 description: An application that can be used to easily enable authentication flows via OIDC for a kubernetes cluster.
 type: application
 home: https://github.com/heptiolabs/gangway

--- a/charts/gangway/README.md
+++ b/charts/gangway/README.md
@@ -39,6 +39,7 @@ You __MUST__ set a `config.sessionSecurityKey`
 | `config.usernameClaim`      | The OIDC username claim                                                   |                     `name`                      |
 | `config.emailClaim`         | The OIDC username claim                                                   |                     `email`                     |
 | `config.sessionSecurityKey` | The cookie security key                                                   |                 `verySecureKey`                 |
+| `existingSecret`            | Specify an existing secret containing clientSecret and sessionSecurityKey |                       ``                        |
 
 ## Use of a selfsigned certificate / custom CA
 

--- a/charts/gangway/templates/config.yaml
+++ b/charts/gangway/templates/config.yaml
@@ -93,6 +93,7 @@ data:
 type: kubernetes.io/tls
 {{- end }}
 {{/* Environment secrets */}}
+{{- if not .Values.existingSecret }}
 ---
 apiVersion: v1
 kind: Secret
@@ -103,6 +104,7 @@ metadata:
 data:
   GANGWAY_CLIENT_SECRET: {{ .Values.config.clientSecret | b64enc | quote }}
   SESSION_SECURITY_KEY: {{ .Values.config.sessionSecurityKey | b64enc | quote }}
+{{- end }}
 {{/* ConfigMap */}}
 ---
 apiVersion: v1

--- a/charts/gangway/templates/deployment.yaml
+++ b/charts/gangway/templates/deployment.yaml
@@ -60,7 +60,11 @@ spec:
             - configMapRef:
                 name: {{ include "gangway.fullname" . }}-env
             - secretRef:
+                {{- if .Values.existingSecret }}
+                name: {{ .Values.existingSecret }}
+                {{- else }}
                 name: {{ include "gangway.fullname" . }}
+                {{- end }}
           volumeMounts:
             - name: config
               mountPath: /etc/gangway/config

--- a/charts/gangway/values.yaml
+++ b/charts/gangway/values.yaml
@@ -103,5 +103,9 @@ config:
   # CHANGE THIS
   sessionSecurityKey: verySecureKey
 
+# if there is already an existingSecret holding sessionSecurityKey and clientSecret, define it here
+# secret must contain following keys: GANGWAY_CLIENT_SECRET, SESSION_SECURITY_KEY
+existingSecret:  ""
+
 customHTMLTemplates:
   enabled: false


### PR DESCRIPTION
Allows us to use an already existing secret, so we don't have to expose secret vars inside the helm values when using gitOPS deployment methods.

Signed-off-by: Toni Tauro <toni.tauro@adfinis.com>
