### PR TITLE
Change Dex Ingress pathType to Prefix

### DIFF
--- a/charts/dex/Chart.yaml
+++ b/charts/dex/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: dex
-version: 4.0.3
+version: 4.0.4
 description: OpenID Connect Identity (OIDC) and OAuth 2.0 Provider with Pluggable Connectors
 type: application
 home: https://github.com/dexidp/dex

--- a/charts/dex/templates/ingress.yaml
+++ b/charts/dex/templates/ingress.yaml
@@ -27,7 +27,7 @@ spec:
         paths:
           {{- range $j, $path := $host.paths }}
           - path: {{ $path }}
-            pathType: Exact
+            pathType: Prefix
             backend:
               service:
                 name: {{ include "dex.fullname" $ }}


### PR DESCRIPTION
Allows Dex endpoints to work, currently it would work only if call goes to root